### PR TITLE
Handle scroll to hide and show the top nav

### DIFF
--- a/src/common/utils/jsVanilla/index.ts
+++ b/src/common/utils/jsVanilla/index.ts
@@ -1,1 +1,2 @@
 export * from './useCarouselEffect';
+export * from './useNavAnimation';

--- a/src/common/utils/jsVanilla/useNavAnimation.ts
+++ b/src/common/utils/jsVanilla/useNavAnimation.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface NavAnimationReturn {
+  /**
+   * Whether the user is at the top of the page.
+   */
+  isAtTop: boolean;
+  /**
+   * Whether the navigation bar is hidden because the user is scrolling down.
+   */
+  isHidden: boolean;
+}
+
+/**
+ * This function is used to hide or show the navigation bar
+ * based on the scroll direction.
+ */
+export const useNavAnimation = (): NavAnimationReturn => {
+  const lastScrollTop = useRef<number>(0);
+
+  const [navState, setNavState] = useState<NavAnimationReturn>({
+    isHidden: false,
+    isAtTop: true
+  });
+
+  useEffect(() => {
+    function handleScroll(): void {
+      /**
+       * Only update the state if the values have changed.
+       */
+      const updateNavState = (newValues: NavAnimationReturn) => {
+        if (newValues.isHidden === navState.isHidden && newValues.isAtTop === navState.isAtTop) return;
+        setNavState(newValues);
+      };
+
+      const currentScrollTop = window.scrollY;
+
+      /**
+       * If the user is at the top of the page or
+       * scrolling up, the navigation bar should be visible.
+       * If the user is scrolling down, the navigation bar should be hidden.
+       */
+      if (currentScrollTop === 0 || currentScrollTop < lastScrollTop.current) {
+        updateNavState({
+          isHidden: false,
+          isAtTop: currentScrollTop === 0
+        });
+      } else if (currentScrollTop > lastScrollTop.current) {
+        updateNavState({
+          isHidden: true,
+          isAtTop: false
+        });
+      }
+
+      lastScrollTop.current = currentScrollTop;
+    }
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [navState]);
+
+  return navState;
+};

--- a/src/components/Navigation/Nav.tsx
+++ b/src/components/Navigation/Nav.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ButtonSize, cn, ROUTE, useBreakpoint, useContributors, VARIANT } from '@common';
+import { ButtonSize, cn, ROUTE, useBreakpoint, useContributors, useNavAnimation, VARIANT } from '@common';
 import { BurgerButton, Button, Logo } from '@components';
 import { Link, NavLink } from 'react-router-dom';
 
@@ -13,19 +13,23 @@ export const Nav = ({ className }: NavProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const { contributors, isLoading } = useContributors();
   const { isMobile } = useBreakpoint();
+  const { isAtTop, isHidden } = useNavAnimation();
   const handleButtonSize = isMobile ? ButtonSize.xl : ButtonSize.base;
 
   const classes = {
     container: cn(
-      'h-20 relative',
+      'h-20 fixed',
       'bg-cBackground/80 backdrop-blur-lg',
-      'md:absolute md:top-6 z-20 md:inset-x-0',
-      'md:bg-cBackground text-gray-400',
+      'md:fixed md:top-6 z-20 md:inset-x-0',
+      'text-gray-400',
       'md:max-w-7xl mx-auto px-6 py-2',
       'flex items-center gap-6',
       'border-b',
       'md:border-[0.2px] border-cBorder md:rounded-full',
       'w-full md:w-fit mx-auto h-fit',
+      'transition-all ease-in-out duration-300',
+      isAtTop ? 'bg-cBackground/80 md:bg-cBackground' : 'bg-cBackground/60 md:bg-cBackground/80',
+      !isAtTop && isHidden && 'translate-y-[-100%] opacity-0',
       className
     ),
     nav: cn(
@@ -42,7 +46,7 @@ export const Nav = ({ className }: NavProps) => {
       'py-5 px-6 md:py-0 md:px-0',
       'flex flex-col gap-6',
       'md:flex-row md:items-center',
-      'bg-cBackground/80 backdrop-blur-lg md:bg-transparent md:backdrop-blur-0',
+      'bg-cBackground/80 backdrop-blur-lg md:bg-transparent md:backdrop-filter-none',
       'max-md:w-[100svw] max-md:h-[100svh]'
     ),
     listItem: (isActive: boolean) =>


### PR DESCRIPTION
## Cambios Realizados 🎉

<!-- Agregar, actualizar o eliminar de abajo -->

- [x] feat: Handle scroll to hide and show the top nav

## Describir Cambios

Added a new hook `useNavAnimation` that uses an event listener to react on any vertical scroll. Returning a state so the nav can be hidden on scroll down and shown on scroll up. 

## Visuales (Opcional)

https://github.com/Afordin/hackafor-2/assets/30253302/de3b2730-8325-4cf0-ad0b-b1b1ca1b72e9

https://github.com/Afordin/hackafor-2/assets/30253302/a2aa1e36-64e2-4276-ba43-7d8e18e9257f


## Lista de Verificación ✅

- [x] Mi código sigue el estilo de código de este proyecto.
