### PR TITLE
fix: top nav hiding when going back from another page

### DIFF
--- a/src/common/utils/jsVanilla/useNavAnimation.ts
+++ b/src/common/utils/jsVanilla/useNavAnimation.ts
@@ -55,9 +55,16 @@ export const useNavAnimation = (): NavAnimationReturn => {
       lastScrollTop.current = currentScrollTop;
     }
 
-    window.addEventListener('scroll', handleScroll);
+    /**
+     * Add a delay to avoid triggering the scroll event when going back
+     * from another page.
+     */
+    const timeoutId = setTimeout(() => {
+      window.addEventListener('scroll', handleScroll);
+    }, 100);
 
     return () => {
+      clearTimeout(timeoutId);
       window.removeEventListener('scroll', handleScroll);
     };
   }, [navState]);

--- a/src/common/utils/jsVanilla/useNavAnimation.ts
+++ b/src/common/utils/jsVanilla/useNavAnimation.ts
@@ -24,6 +24,36 @@ export const useNavAnimation = (): NavAnimationReturn => {
   });
 
   useEffect(() => {
+    /**
+     * Handle the scroll event when the page is loaded to
+     * update the state of the navigation bar.
+     */
+    function handleScrollOnLoad() {
+      setNavState((prevState) => ({
+        ...prevState,
+        isAtTop: window.scrollY === 0
+      }));
+
+      lastScrollTop.current = window.scrollY;
+    }
+
+    window.addEventListener('scroll', handleScrollOnLoad);
+
+    /**
+     * Remove the event listener after a delay since we only
+     * want to trigger it once.
+     */
+    const timeoutId = setTimeout(() => {
+      window.removeEventListener('scroll', handleScrollOnLoad);
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('scroll', handleScrollOnLoad);
+    };
+  }, []);
+
+  useEffect(() => {
     function handleScroll(): void {
       /**
        * Only update the state if the values have changed.
@@ -56,7 +86,7 @@ export const useNavAnimation = (): NavAnimationReturn => {
     }
 
     /**
-     * Add a delay to avoid triggering the scroll event when going back
+     * Add a delay to avoid triggering this scroll event when going back
      * from another page.
      */
     const timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Cambios Realizados 🎉

- [x] fix:  top nav hiding when going back from another page

## Describir Cambios

There was an issue when doing this flow:

1. User enters page and scrolls down. (Top nav hides)
2. Scroll up to show nav, clicks on an option and gets redirected to another page.
3. Clicks on browser back button. (<kbd>Alt</kbd> + <kbd>←</kbd>)

The result of this flow would be that the previous page scroll state would be maintained but our logic nav state wouldn't. Additionally, on render the scroll event would be triggered and it would be interpreted as a scroll down from the user. This caused the top nav to hide unnecessarily.

The fix is composed of 2 parts:

- Avoid triggering the scroll handler on page load.
This will fix the top nav being hidden on load.
- Use an specific handler for the first scroll event to sync our nav state with the page scroll state.
This will avoid an unnecessary animation that would happen when scrolling up after going back. It happened because the hidden state would go `false -> true -> false`.

## Visuales (Opcional)

Before:

https://github.com/Afordin/hackafor-2/assets/30253302/a4666ae3-9a5a-49b8-bb04-cbc81781d3cd

After:

https://github.com/Afordin/hackafor-2/assets/30253302/594346de-3f9c-4013-9f61-bf3b4b15fcef

## Lista de Verificación ✅

- [x] Mi código sigue el estilo de código de este proyecto.
