### PR TITLE
fix: font size on ticket

### DIFF
--- a/src/pages/_sections/Ticket.tsx
+++ b/src/pages/_sections/Ticket.tsx
@@ -41,7 +41,11 @@ export const Ticket: FC<TicketProps> = ({
                     alt={`Avatar de ${name}`}
                   />
                   <div className="flex flex-col gap-3 justify-center">
-                    <h3 title={name} data-atropos-offset="3" className={`flex font-bold text-lg sm:text-3xl md:text-4xl`}>
+                    <h3
+                      title={name}
+                      data-atropos-offset="3"
+                      className={`flex font-bold text-lg sm:text-3xl md:${name.length > 15 ? 'text-2xl' : 'text-4xl'}`}
+                    >
                       {name}
                     </h3>
                     <span data-atropos-offset="4" className={`flex gap-1 items-center`}>


### PR DESCRIPTION
## Changes made ✨

### In the ticket when the name was too big it left its container
#### This was what it looked like. 👀
![image](https://github.com/Afordin/hackafor-2/assets/110699874/d68afd59-96ee-4eff-b60c-0068c4e9bcf1)#### But with the changes made it looks like this 🚀
### The name becomes smaller when its length is greater than 15
![image](https://github.com/Afordin/hackafor-2/assets/110699874/994ddd87-2134-4165-95ac-4639aaf8e47e)