### PR TITLE
fix(Nav): remove overflow hidden correctly after navigating on mobile

### DIFF
--- a/src/components/Navigation/Nav.tsx
+++ b/src/components/Navigation/Nav.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AvatarSize, ButtonSize, cn, ROUTE, useAuth, useBreakpoint, useContributors, useNavAnimation, Variant } from '@common';
 import { Avatar, BurgerButton, Button, Logo } from '@components';
 import { useUserStore } from '@store';
@@ -82,12 +82,18 @@ export const Nav = ({ className }: NavProps) => {
       </a>
     ));
 
-  const handleClick = () => {
-    if (isMobile) {
-      document.body.style.overflow = isOpen ? 'auto' : 'hidden';
+  /**
+   * overflow "hidden" needs to be set when the component isOpen (mounts)
+   * return to "auto" when it (unmonuts)
+   */
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
     }
-    setIsOpen(!isOpen);
-  };
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [isOpen]);
 
   return (
     <header className={classes.container}>
@@ -153,7 +159,7 @@ export const Nav = ({ className }: NavProps) => {
         </ul>
       </nav>
 
-      <BurgerButton isOpen={isOpen} onClick={handleClick} className="md:hidden" />
+      <BurgerButton isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} className="md:hidden" />
     </header>
   );
 };


### PR DESCRIPTION
## Changes Made 🎉

<!-- Add, update or remove from below -->

- [ ] feat: added new feature to improve user experience
- [x] fix: corrected a bug with login functionality
- [ ] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Describe
the overflow hidden on the body wouldn't switch to "auto" after the user click a link on mobile, this new implementation checks whether the navigation section in mounted or not to set the correct overflow on the body.

<!--- Add video or images showcasing the changes or demonstrating the functionality ---> 

https://github.com/Afordin/hackafor-2/assets/114157492/78b9d038-49d2-418f-9fbf-0617d21aced9



## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
