### PR TITLE
fix(Popover): safari flicker bug

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -71,7 +71,6 @@ export const Popover = ({
       'shadow-lg z-50',
       'rounded-md',
       'p-2 text-sm',
-      'transition-all',
       {
         'opacity-0 invisible': !open,
         'opacity-100 animate-fade-in animate-duration-200': open


### PR DESCRIPTION
## Changes 🎉

<!-- Add, update or remove from below -->

- [ ] feat: added new feature to improve user experience
- [x] fix: popover flicker effect on Safari fixed
- [ ] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Describe Changes
Found a small bug on Safari, the popover would flicker because of the class "transition-all", seemed unnecessary, deleting it fixed the issue.

## Visuals (Optional)
### Before

https://github.com/Afordin/hackafor-2/assets/114157492/072edeaf-de47-42be-8878-643111b6d649

### After

https://github.com/Afordin/hackafor-2/assets/114157492/ca24b0e9-5864-47bb-922b-2f610d6a0742

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
