### PR TITLE
fix: popover trigger placement and list of members sorted

### DIFF
--- a/src/common/utils/parser/groupParticipantsByRole.ts
+++ b/src/common/utils/parser/groupParticipantsByRole.ts
@@ -29,8 +29,9 @@ import { User } from '../../types';
    }
  */
 
-export function groupParticipantsByRole(membersObj: User[], administrator: User) {
-  const grouped = membersObj.concat(administrator).reduce(
+export function groupParticipantsByRole(membersObj: User[], administratorObj: User) {
+  const grouped = [administratorObj].concat(membersObj).reduce(
+    // thanks Marcos <3!
     (acc, obj) => {
       if (!acc[obj.role]) {
         acc[obj.role] = [];

--- a/src/components/Cards/ProjectCard/ProjectCard.tsx
+++ b/src/components/Cards/ProjectCard/ProjectCard.tsx
@@ -41,7 +41,8 @@ export const ProjectCard = ({
     list: cn('flex flex-wrap gap-4 mt-4 text-3.5'),
     popoverTrigger: cn(
       'bg-gradient-to-rb from-primary-600 to-secondary-500 w-5 h-5 rounded-full text-xs flex items-center justify-center cursor-pointer select-none'
-    )
+    ),
+    adminBadge: cn('text-xs bg-gradient-to-rb from-primary-600 to-secondary-500 text-transparent bg-clip-text rounded-full')
   };
 
   const handleDescription = () => {
@@ -60,9 +61,9 @@ export const ProjectCard = ({
     const participantList = participantsByRole[role].map((participant, idx) => {
       const isAdmin = Object.values(administrator).includes(participant.name);
       return (
-        <li className="text-cWhite capitalize px-1 py-0.5 flex gap-1" key={participant.name + idx}>
+        <li className="text-cWhite capitalize px-1 py-0.5 flex items-center gap-1.5" key={participant.name + idx}>
           {participant.name}
-          {isAdmin && <span className="text-secondary-600">{'(Adm)'}</span>}
+          {isAdmin && <span className={classes.adminBadge}>{'(admin)'}</span>}
         </li>
       );
     });
@@ -70,9 +71,9 @@ export const ProjectCard = ({
     return (
       <li key={role + idx}>
         {/** TODO: change key later 😒 Why later?*/}
-        <Tag>
-          <div className="flex items-center gap-2">
-            {role}
+        <Tag className="relative capitalize">
+          <span>{role}</span>
+          <div className="absolute -right-2 -top-2">
             <Popover content={<ul>{participantList}</ul>}>
               <span className={classes.popoverTrigger}>{groupLength}</span>
             </Popover>

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -57,7 +57,7 @@ interface TagProps {
 export const Tag = ({ children, variant = TagVariant.primary, size = TagSize.sm, className, borderSize = TagSize.xs }: TagProps) => {
   const classes = {
     container: cn('flex items-center justify-center rounded-full w-fit', TagContainerVariants[variant], BorderSizes[borderSize], className),
-    tag: cn('rounded-full py-px px-2', TagVariants[variant], Sizes[size])
+    tag: cn('rounded-full py-0.5 px-3', TagVariants[variant], Sizes[size])
   };
 
   return (


### PR DESCRIPTION
## Changes Made 🎉

<!-- Add, update or remove from below -->

- [ ] feat: added new feature to improve user experience
- [x] fix: solved the popoverTrigger placement and list of members sorted
- [ ] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Changes
- The popover trigger has a new position in the roles Tag
- groupParticipantsByRole function improved so the list of members starts with the administrator (thanks to Marcos)
- Small styling changes like paddings, text color, etc, for enhancement

## Visuals

### Before
<img width="427" alt="Screenshot 2024-04-16 at 17 46 59" src="https://github.com/Afordin/hackafor-2/assets/114157492/5b688513-29a5-4e06-82a3-66e3cc9c4d72">

### After
<img width="432" alt="Screenshot 2024-04-16 at 17 45 47" src="https://github.com/Afordin/hackafor-2/assets/114157492/4d5b49f7-11c8-447d-813c-0eddfad2ffee">


## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
