### PR TITLE
fix: init timer now starts correctly

### DIFF
--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 export const Countdown = () => {
   const time = [
@@ -27,19 +27,27 @@ export const Countdown = () => {
     seconds: 0
   });
 
+  const updateCountdown = () => {
+    const countdownDate = new Date('2024-11-20');
+    const now = new Date();
+
+    const timeDifference = countdownDate.getTime() - now.getTime();
+
+    const days = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((timeDifference / (1000 * 60 * 60)) % 24);
+    const minutes = Math.floor((timeDifference / (1000 * 60)) % 60);
+    const seconds = Math.floor((timeDifference / 1000) % 60);
+
+    setTimeLeft({ days, hours, minutes, seconds });
+  };
+
+  useLayoutEffect(() => {
+    // updateCountdown()
+  }, []);
+
   useEffect(() => {
     setInterval(() => {
-      const countdownDate = new Date('2024-11-20');
-      const now = new Date();
-
-      const timeDifference = countdownDate.getTime() - now.getTime();
-
-      const days = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
-      const hours = Math.floor((timeDifference / (1000 * 60 * 60)) % 24);
-      const minutes = Math.floor((timeDifference / (1000 * 60)) % 60);
-      const seconds = Math.floor((timeDifference / 1000) % 60);
-
-      setTimeLeft({ days, hours, minutes, seconds });
+      updateCountdown();
     }, 1000);
   }, []);
 

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -42,7 +42,7 @@ export const Countdown = () => {
   };
 
   useLayoutEffect(() => {
-    // updateCountdown()
+    updateCountdown();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Changes Made 🎉

<!-- Add, update or remove from below -->

- [ ] feat: added new feature to improve user experience
- [x] fix: corrected a bug with login functionality
- [x] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Describe Changes

The countdown timer starts at 0 when the page is loaded. However, there's a delay because the setInterval function takes 1 second to apply. To ensure timely updates, I've created a function called updateCountdown. This function is invoked within a useLayoutEffect hook to take effect before the page renders. Additionally, I've created a separate function to avoid code repetition within both the useLayoutEffect and useEffect hooks."

## Related Issue(s)

- Issue Number

## Visuals (Optional)

### Before

![init-time](https://github.com/Afordin/hackafor-2/assets/99609346/0d3ce3e4-02cf-4175-972e-e8de9c0cad7d)

### After

![init timer](https://github.com/Afordin/hackafor-2/assets/99609346/d8b2bf69-e376-43d2-abe6-da61f3e81246)



## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
