### PR TITLE
Fix hook ClickOutSide

### DIFF
--- a/src/common/hooks/useOnClickOutside/useOnClickOutside.ts
+++ b/src/common/hooks/useOnClickOutside/useOnClickOutside.ts
@@ -2,9 +2,14 @@ import { RefObject, useEffect, useRef } from 'react';
 
 type Event = MouseEvent | TouchEvent;
 
+type HandlerType = {
+  event: Event;
+  isSameTrigger: boolean;
+};
+
 export const useOnClickOutside = <T extends HTMLElement>(
   ref: RefObject<HTMLElement> | HTMLElement | null,
-  handler: ({ event: Event, isSameTrigger: boolean }) => void
+  handler: (params: HandlerType) => void
 ) => {
   const trigger = useRef<T>(null);
 
@@ -18,7 +23,7 @@ export const useOnClickOutside = <T extends HTMLElement>(
       if (!element) return;
       if (!element || element.contains(target)) return;
 
-      handler({ event, isSameTrigger: trigger.current?.contains(target) });
+      handler({ event, isSameTrigger: Boolean(trigger.current?.contains(target)) });
     };
 
     document.addEventListener('mousedown', listener);

--- a/src/components/Navigation/LoggedUser.tsx
+++ b/src/components/Navigation/LoggedUser.tsx
@@ -24,13 +24,15 @@ export const LoggedUser: FC<Props> = ({ className, user, avatarSize = AvatarSize
 
   const modalRef = useRef<HTMLDivElement | null>(null);
 
-  useOnClickOutside(modalRef, () => setIsOpen(false));
+  const trigger = useOnClickOutside(modalRef, ({ isSameTrigger }) => setIsOpen(isSameTrigger));
 
   const classes = {
-    container: ` flex w-fit h-full items-center relative gap-4 text-white ${className}`,
-    expandIcon: 'absolute bottom-[-5px] right-[-5px] text-inherit font-bold text-lg',
+    container: cn('flex w-fit h-full items-center relative gap-4 text-white', className),
+    expandIcon: cn('i-material-symbols-expand-more absolute bottom-[-5px] right-[-5px] text-inherit font-bold text-lg', {
+      'text-yellow': isOpen
+    }),
     text: 'flex text-white hover:text-primary-400 items-center gap-3 text-inherit bg-transparent rounded-lg font-semibold text-sm cursor-pointer',
-    modal: 'absolute top-10  right-[-5px] border-1 border-cBorder rounded-lg px-5 py-2 bg-cBackground w-40 cursor-pointer'
+    modal: 'absolute top-10 right-[-5px] border-1 border-cBorder rounded-lg px-5 py-2 bg-cBackground w-40 cursor-pointer'
   };
 
   return isMobile ? (
@@ -38,21 +40,15 @@ export const LoggedUser: FC<Props> = ({ className, user, avatarSize = AvatarSize
       Salir
     </span>
   ) : (
-    <div className={classes.container} ref={modalRef}>
-      <span
-        className="relative cursor-pointer"
-        onClick={() => {
-          setIsOpen(!isOpen);
-        }}
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        <span className={cn('i-material-symbols-expand-more', classes.expandIcon, isOpen && 'text-yellow')} />
+    <div className={classes.container}>
+      <span className="relative cursor-pointer" ref={trigger} onClick={() => setIsOpen(!isOpen)}>
+        <span className={classes.expandIcon} />
         <Avatar avatar={user.user_metadata.avatar_url} size={avatarSize} />
       </span>
       {/* modal */}
       {isOpen && (
-        <div className={classes.modal}>
-          <p className={classes.text} onMouseDown={(e) => e.stopPropagation()} onClick={signOut}>
+        <div className={classes.modal} ref={modalRef}>
+          <p className={classes.text} onClick={signOut}>
             <span className="i-material-symbols-exit-to-app-rounded" />
             Cerrar sesión
           </p>


### PR DESCRIPTION
## Changes Made 🎉

<!-- Add, update or remove from below -->

- [ ] feat: added new feature to improve user experience
- [x] fix: corrected a bug with login functionality
- [ ] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Describe Changes

Update hook `useOnClickOutside` because it presents a popover bug when clicking on the same target that creates the popover.

## Related Issue(s)

[- Issue Number](https://github.com/Afordin/hackafor-2/issues/118)

## Visuals (Optional)

**Before:**

https://github.com/Afordin/hackafor-2/assets/66183680/ecbca82b-4197-4041-8608-a1e1d80e310d

**After:**

https://github.com/Afordin/hackafor-2/assets/66183680/1842b14f-33cd-445e-9cf3-0476bc3c9cf6

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
